### PR TITLE
mechanisms to set TOS/DSCP on the outgoing ciphered connections

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,4 +242,35 @@ AM_COND_IF([ENABLE_DOCUMENTATION],
   [AC_CONFIG_FILES([doc/Makefile])
 ])
 
+AC_ARG_ENABLE(connmarktos,
+[AS_HELP_STRING(--enable-connmarktos, Enable saved connmark to IP TOS QoS feature)],
+[
+  enable_connmarktos="yes"
+],
+[
+  enable_connmarktos="no"
+])
+
+if test x"$enable_connmarktos" = "xyes" ; then
+	AC_MSG_NOTICE([Linux Netfilter Conntrack support requested by --enable-connmarktos: ${enable_connmarktos}])
+	if test "x$enable_connmarktos" != "xno"; then
+	    AC_SEARCH_LIBS([nfct_query], [netfilter_conntrack],,[
+	        if test x"$enable_connmarktos" = "xyes"; then
+	            AC_MSG_ERROR([--enable-connmarktos specified but libnetfilter-conntrack library not found])
+	        fi
+	        with_netfilter_conntrack=no])
+	    AC_CHECK_HEADERS([libnetfilter_conntrack/libnetfilter_conntrack.h \
+	        libnetfilter_conntrack/libnetfilter_conntrack_tcp.h],,[
+	        if test x"$enable_connmarktos" = "xyes"; then
+	            AC_MSG_ERROR([--enable-connmarktos specified but libnetfilter-conntrack headers not found])
+	        fi
+	        with_netfilter_conntrack=no])
+	  # If nothing is broken; enable the libraries usage.
+	  if test "x$with_netfilter_conntrack" != "xno"; then
+		with_netfilter_conntrack=yes
+		AC_DEFINE(USE_NFCONNTRACK_TOS, 1, [Enable support for QOS netfilter mark preservation])
+	  fi
+	fi
+fi
+
 AC_OUTPUT

--- a/src/jconf.h
+++ b/src/jconf.h
@@ -24,11 +24,21 @@
 
 #define MAX_PORT_NUM 1024
 #define MAX_REMOTE_NUM 10
+#define MAX_DSCP_NUM 64
 #define MAX_CONF_SIZE 128 * 1024
 #define MAX_DNS_NUM 4
 #define MAX_CONNECT_TIMEOUT 10
 #define MAX_REQUEST_TIMEOUT 60
 #define MIN_UDP_TIMEOUT 10
+
+#define DSCP_EF      0x2E
+#define DSCP_MIN     0x0
+#define DSCP_MAX     0x3F
+#define DSCP_DEFAULT 0x0
+#define DSCP_MIN_LEN 2
+#define DSCP_MAX_LEN 4
+#define DSCP_CS_LEN  3
+#define DSCP_AF_LEN  4
 
 #define TCP_ONLY     0
 #define TCP_AND_UDP  1
@@ -43,6 +53,11 @@ typedef struct {
     char *port;
     char *password;
 } ss_port_password_t;
+
+typedef struct {
+    char *port;
+    int dscp;
+} ss_dscp_t;
 
 typedef struct {
     int remote_num;
@@ -63,6 +78,8 @@ typedef struct {
     int reuse_port;
     int nofile;
     char *nameserver;
+    int dscp_num;
+    ss_dscp_t dscp[MAX_DSCP_NUM];
     char *tunnel_address;
     int mode;
     int mtu;

--- a/src/redir.c
+++ b/src/redir.c
@@ -783,6 +783,12 @@ accept_cb(EV_P_ ev_io *w, int revents)
     // Set non blocking
     setnonblocking(remotefd);
 
+    if (listener->tos >= 0) {
+        if (setsockopt(remotefd, IPPROTO_IP, IP_TOS, &listener->tos, sizeof(listener->tos)) != 0) {
+            ERROR("setsockopt IP_TOS");
+        }
+    }
+
     // Enable MPTCP
     if (listener->mptcp > 1) {
         int err = setsockopt(remotefd, SOL_TCP, listener->mptcp, &opt, sizeof(opt));
@@ -879,6 +885,9 @@ main(int argc, char **argv)
     int remote_num = 0;
     ss_addr_t remote_addr[MAX_REMOTE_NUM];
     char *remote_port = NULL;
+
+    int dscp_num   = 0;
+    ss_dscp_t * dscp = NULL;
 
     static struct option long_options[] = {
         { "fast-open",   no_argument,       NULL, GETOPT_VAL_FAST_OPEN },
@@ -1058,6 +1067,8 @@ main(int argc, char **argv)
             nofile = conf->nofile;
         }
 #endif
+	dscp_num = conf->dscp_num;
+	dscp = conf->dscp;
     }
 
     if (remote_num == 0 || remote_port == NULL || local_port == NULL
@@ -1184,44 +1195,59 @@ main(int argc, char **argv)
 
     struct ev_loop *loop = EV_DEFAULT;
 
-    if (mode != UDP_ONLY) {
-        // Setup socket
-        int listenfd;
-        listenfd = create_and_bind(local_addr, local_port);
-        if (listenfd == -1) {
-            FATAL("bind() error");
+    listen_ctx_t* listen_ctx_current = &listen_ctx;
+    do {
+        if (mode != UDP_ONLY) {
+            // Setup socket
+            int listenfd;
+            listenfd = create_and_bind(local_addr, local_port);
+            if (listenfd == -1) {
+               FATAL("bind() error");
+            }
+            if (listen(listenfd, SOMAXCONN) == -1) {
+               FATAL("listen() error");
+            }
+            setnonblocking(listenfd);
+
+            listen_ctx_current->fd = listenfd;
+
+            ev_io_init(&listen_ctx_current->io, accept_cb, listenfd, EV_READ);
+            ev_io_start(loop, &listen_ctx_current->io);
         }
-        if (listen(listenfd, SOMAXCONN) == -1) {
-            FATAL("listen() error");
+
+        // Setup UDP
+        if (mode != TCP_ONLY) {
+            LOGI("UDP relay enabled");
+            char *host = remote_addr[0].host;
+            char *port = remote_addr[0].port == NULL ? remote_port : remote_addr[0].port;
+            struct sockaddr_storage *storage = ss_malloc(sizeof(struct sockaddr_storage));
+            memset(storage, 0, sizeof(struct sockaddr_storage));
+            if (get_sockaddr(host, port, storage, 1, ipv6first) == -1) {
+                FATAL("failed to resolve the provided hostname");
+            }
+            struct sockaddr *addr = (struct sockaddr *)storage;
+            init_udprelay(local_addr, local_port, addr,
+                          get_sockaddr_len(addr), mtu, crypto, listen_ctx_current->timeout, NULL);
         }
-        setnonblocking(listenfd);
 
-        listen_ctx.fd = listenfd;
-
-        ev_io_init(&listen_ctx.io, accept_cb, listenfd, EV_READ);
-        ev_io_start(loop, &listen_ctx.io);
-    }
-
-    // Setup UDP
-    if (mode != TCP_ONLY) {
-        LOGI("UDP relay enabled");
-        char *host = remote_addr[0].host;
-        char *port = remote_addr[0].port == NULL ? remote_port : remote_addr[0].port;
-        struct sockaddr_storage *storage = ss_malloc(sizeof(struct sockaddr_storage));
-        memset(storage, 0, sizeof(struct sockaddr_storage));
-        if (get_sockaddr(host, port, storage, 1, ipv6first) == -1) {
-            FATAL("failed to resolve the provided hostname");
+        if (mode == UDP_ONLY) {
+            LOGI("TCP relay disabled");
         }
-        struct sockaddr *addr = (struct sockaddr *)storage;
-        init_udprelay(local_addr, local_port, addr,
-                      get_sockaddr_len(addr), mtu, crypto, listen_ctx.timeout, NULL);
-    }
 
-    if (mode == UDP_ONLY) {
-        LOGI("TCP relay disabled");
-    }
+        if(listen_ctx_current->tos) {
+            LOGI("listening at %s:%s (TOS/DSCP 0x%x)", local_addr, local_port, listen_ctx_current->tos);
+        } else {
+            LOGI("listening at %s:%s", local_addr, local_port);
+        }
 
-    LOGI("listening at %s:%s", local_addr, local_port);
+        // Handle additionals TOS/DSCP listening ports
+        if (dscp_num > 0) {
+            listen_ctx_current = (listen_ctx_t*) malloc(sizeof(listen_ctx_t));
+            listen_ctx_current = memcpy(listen_ctx_current, &listen_ctx, sizeof(listen_ctx_t));
+            local_port = dscp[dscp_num-1].port;
+            listen_ctx_current->tos = dscp[dscp_num-1].dscp;
+        }
+    } while (dscp_num-- > 0);
 
     // setuid
     if (user != NULL && !run_as(user)) {

--- a/src/redir.h
+++ b/src/redir.h
@@ -37,6 +37,7 @@ typedef struct listen_ctx {
     int timeout;
     int fd;
     int mptcp;
+    int tos;
     struct sockaddr **remote_addr;
 } listen_ctx_t;
 

--- a/src/server.c
+++ b/src/server.c
@@ -78,6 +78,18 @@
 #define MAX_FRAG 1
 #endif
 
+#ifdef USE_NFCONNTRACK_TOS
+
+#ifndef MARK_MAX_PACKET
+#define MARK_MAX_PACKET 10
+#endif
+
+#ifndef MARK_MASK_PREFIX
+#define MARK_MASK_PREFIX 0xDC00
+#endif
+
+#endif
+
 static void signal_cb(EV_P_ ev_signal *w, int revents);
 static void accept_cb(EV_P_ ev_io *w, int revents);
 static void server_send_cb(EV_P_ ev_io *w, int revents);
@@ -548,6 +560,93 @@ connect_to_remote(EV_P_ struct addrinfo *res,
     return remote;
 }
 
+#ifdef USE_NFCONNTRACK_TOS
+int setMarkDscpCallback(enum nf_conntrack_msg_type type, struct nf_conntrack *ct, void *data)
+{
+	server_t* server = (server_t*) data;
+	struct dscptracker* tracker = server->tracker;
+
+	tracker->mark = nfct_get_attr_u32(ct, ATTR_MARK);
+	if ((tracker->mark & 0xff00) == MARK_MASK_PREFIX) {
+		// Extract DSCP value from mark value
+		tracker->dscp = tracker->mark & 0x00ff;
+		int tos = (tracker->dscp) << 2;
+		if (setsockopt(server->fd, IPPROTO_IP, IP_TOS, &tos, sizeof(tos)) != 0) {
+			ERROR("iptable setsockopt IP_TOS");
+		};
+	}
+	return NFCT_CB_CONTINUE;
+}
+
+void conntrackQuery(server_t* server) {
+	struct dscptracker* tracker = server->tracker;
+	if(tracker && tracker->ct) {
+		// Trying query mark from nf conntrack
+		struct nfct_handle *h = nfct_open(CONNTRACK, 0);
+		if (h) {
+			nfct_callback_register(h, NFCT_T_ALL, setMarkDscpCallback, (void*) server);
+			int x = nfct_query(h, NFCT_Q_GET, tracker->ct);
+			if (x == -1) {
+				LOGE("QOS: Failed to retrieve connection mark %s", strerror(errno));
+			}
+			nfct_close(h);
+		} else {
+			LOGE("QOS: Failed to open conntrack handle for upstream netfilter mark retrieval.");
+		}
+	}
+}
+
+void setTosFromConnmark(remote_t* remote, server_t* server)
+{
+	if(server->tracker && server->tracker->ct) {
+		if(server->tracker->mark == 0 && server->tracker->packet_count < MARK_MAX_PACKET) {
+			server->tracker->packet_count++;
+			conntrackQuery(server);
+		}
+	} else {
+		socklen_t len;
+		struct sockaddr_storage sin;
+		len = sizeof(sin);
+		if (getsockname(remote->fd, (struct sockaddr *)&sin, &len) == 0) {
+			struct sockaddr_storage from_addr;
+			len = sizeof from_addr;
+			if(getpeername(remote->fd, (struct sockaddr*)&from_addr, &len) == 0) {
+				if((server->tracker = (struct dscptracker*) malloc(sizeof(struct dscptracker))))
+				{
+					if ((server->tracker->ct = nfct_new())) {
+						// Build conntrack query SELECT
+						if (from_addr.ss_family == AF_INET) {
+							struct sockaddr_in *src = (struct sockaddr_in *)&from_addr;
+							struct sockaddr_in *dst = (struct sockaddr_in *)&sin;
+
+							nfct_set_attr_u8(server->tracker->ct, ATTR_L3PROTO, AF_INET);
+							nfct_set_attr_u32(server->tracker->ct, ATTR_IPV4_DST, dst->sin_addr.s_addr);
+							nfct_set_attr_u32(server->tracker->ct, ATTR_IPV4_SRC, src->sin_addr.s_addr);
+							nfct_set_attr_u16(server->tracker->ct, ATTR_PORT_DST, dst->sin_port);
+							nfct_set_attr_u16(server->tracker->ct, ATTR_PORT_SRC, src->sin_port);
+						} else if (from_addr.ss_family == AF_INET6) {
+							struct sockaddr_in6 *src = (struct sockaddr_in6 *)&from_addr;
+							struct sockaddr_in6 *dst = (struct sockaddr_in6 *)&sin;
+
+							nfct_set_attr_u8(server->tracker->ct, ATTR_L3PROTO, AF_INET6);
+							nfct_set_attr(server->tracker->ct, ATTR_IPV6_DST, dst->sin6_addr.s6_addr);
+							nfct_set_attr(server->tracker->ct, ATTR_IPV6_SRC, src->sin6_addr.s6_addr);
+							nfct_set_attr_u16(server->tracker->ct, ATTR_PORT_DST, dst->sin6_port);
+							nfct_set_attr_u16(server->tracker->ct, ATTR_PORT_SRC, src->sin6_port);
+						}
+						nfct_set_attr_u8(server->tracker->ct, ATTR_L4PROTO, IPPROTO_TCP);
+						conntrackQuery(server);
+					} else {
+						LOGE("Failed to allocate new conntrack for upstream netfilter mark retrieval.");
+						server->tracker->ct=NULL;
+					};
+				}
+			}
+		}
+	}
+}
+#endif
+
 static void
 server_recv_cb(EV_P_ ev_io *w, int revents)
 {
@@ -1001,6 +1100,9 @@ remote_recv_cb(EV_P_ ev_io *w, int revents)
         return;
     }
 
+#ifdef USE_NFCONNTRACK_TOS
+    setTosFromConnmark(remote, server);
+#endif
     int s = send(server->fd, server->buf->data, server->buf->len, 0);
 
     if (s == -1) {
@@ -1229,6 +1331,17 @@ new_server(int fd, listen_ctx_t *listener)
 static void
 free_server(server_t *server)
 {
+#ifdef USE_NFCONNTRACK_TOS
+    if(server->tracker) {
+        struct dscptracker* tracker = server->tracker;
+        struct nf_conntrack* ct = server->tracker->ct;
+        server->tracker = NULL;
+        if (ct) {
+            nfct_destroy(ct);
+       }
+       free(tracker);
+    };
+#endif
     cork_dllist_remove(&server->entries);
 
     if (server->remote != NULL) {

--- a/src/server.h
+++ b/src/server.h
@@ -53,6 +53,20 @@ typedef struct server_ctx {
     struct server *server;
 } server_ctx_t;
 
+#ifdef USE_NFCONNTRACK_TOS
+
+#include <libnetfilter_conntrack/libnetfilter_conntrack.h>
+#include <libnetfilter_conntrack/libnetfilter_conntrack_tcp.h>
+
+struct dscptracker {
+        struct nf_conntrack *ct;
+        long unsigned int mark;
+        unsigned int dscp;
+        unsigned int packet_count;
+};
+
+#endif
+
 typedef struct server {
     int fd;
     int stage;
@@ -70,6 +84,9 @@ typedef struct server {
     struct ResolvQuery *query;
 
     struct cork_dllist_item entries;
+#ifdef USE_NFCONNTRACK_TOS
+    struct dscptracker* tracker;
+#endif
 } server_t;
 
 typedef struct query {


### PR DESCRIPTION
As IP headers are not reachable by application from the socket user-space, we need a workaround to pass the TOS value from local traffic to the outgoing ciphered traffic and then apply some traffic control rules based on the IP TOS value. 

ss-server:
This patch, allows you to set a TOS/DSCP value to the outgoing ciphered connections to the client from a netfilter mark setted to the (re)comming connection from the outside world. TOS/DSCP value is extracted from the 16 bits mark with a mask on the lower bits, upper bits of the mask must be set to 0xDC (ex: a mark with value 0xDC08 will set a TOS/DSCP of 0x08 to the ciphered connection).

This feature is based on libnetfilter-conntrack and is disabled by default and must be configured with the --enable-connmarktos flags to be used.

ss-redir : 
- This patch, allow you to select a TOS/DSCP value on additional listening sockets that will report the selected TOS/DSCP value on the outgoing ciphered connection.

We added a dscp section in the json conf to define those ports
```
    "local_port": 8388,
    "dscp": {
                "8389": "CS1",
                "8390": "CS2",
                "8391": "CS3",
                "8392": "CS4",
                "8393": "CS5",
                "8394": "CS6",
                "8395": "CS7"
        }
```
That will make ss-redir to listen on these specified ports : 
```
sduponch@test:~/overthebox-shadowsocks-libev$ ./src/ss-redir -c src/shadowsocks.json 
 2017-03-07 13:51:50 INFO: initializing ciphers... aes-256-cfb
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8388
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8389 (TOS/DSCP 0x8)
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8390 (TOS/DSCP 0x10)
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8391 (TOS/DSCP 0x18)
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8392 (TOS/DSCP 0x20)
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8393 (TOS/DSCP 0x28)
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8394 (TOS/DSCP 0x30)
 2017-03-07 13:51:50 INFO: listening at 127.0.0.1:8395 (TOS/DSCP 0x38)
```
Then we only have to dispatch the incoming classified traffic with iptables : 
```
-A socks_redir -p tcp -m dscp --dscp 0x08 -m comment --comment CS1 -j REDIRECT --to-ports 8389
-A socks_redir -p tcp -m dscp --dscp 0x10 -m comment --comment CS2 -j REDIRECT --to-ports 8390
-A socks_redir -p tcp -m dscp --dscp 0x18 -m comment --comment CS3 -j REDIRECT --to-ports 8391
-A socks_redir -p tcp -m dscp --dscp 0x20 -m comment --comment CS4 -j REDIRECT --to-ports 8392
-A socks_redir -p tcp -m dscp --dscp 0x28 -m comment --comment CS5 -j REDIRECT --to-ports 8393
-A socks_redir -p tcp -m dscp --dscp 0x30 -m comment --comment CS6 -j REDIRECT --to-ports 8394
-A socks_redir -p tcp -m dscp --dscp 0x38 -m comment --comment CS7 -j REDIRECT --to-ports 8395
-A socks_redir -p tcp -j REDIRECT --to-ports 8388
```
Then you need to setup a TC script that take care of the IP TOS value and assign that flows to your traffic control queues.